### PR TITLE
Moved BAND definition from Network.h into the Flutter.h

### DIFF
--- a/examples/Blink/Blink.ino
+++ b/examples/Blink/Blink.ino
@@ -26,6 +26,7 @@ Flutter flutter;
 void setup()
 {
 	Serial.begin(115200);
+	flutter.band = NORTH_AMERICA;
 	flutter.setNetworkName("Home network");
 	//pinMode(6,OUTPUT);
 	//pinMode(7,OUTPUT);

--- a/examples/Joystick/Joystick.ino
+++ b/examples/Joystick/Joystick.ino
@@ -28,6 +28,7 @@ Flutter flutter;
 void setup()
 {
 	Serial.begin(115200);
+	flutter.band = NORTH_AMERICA;
 	flutter.setNetworkName("Home network");
 	//pinMode(6,OUTPUT);
 	//pinMode(7,OUTPUT);

--- a/examples/RangeTest/RangeTest.ino
+++ b/examples/RangeTest/RangeTest.ino
@@ -30,6 +30,7 @@ byte mydata = 0;
 void setup()
 {
 	Serial.begin(115200);
+	flutter.band = NORTH_AMERICA;
 	flutter.setNetworkName("Range Test");
 	Serial.println("Initializing...");
 

--- a/examples/RemoteControlCar/RemoteControlCar.ino
+++ b/examples/RemoteControlCar/RemoteControlCar.ino
@@ -29,6 +29,7 @@ Flutter flutter;
 void setup()
 {
 	Serial.begin(115200);
+	flutter.band = NORTH_AMERICA;
 	flutter.setNetworkName("Home network");
 	pinMode(STEERINGPIN, OUTPUT);
 	pinMode(THROTTLEPIN, OUTPUT);

--- a/src/Flutter.cpp
+++ b/src/Flutter.cpp
@@ -39,7 +39,7 @@ Flutter::Flutter()
 
 boolean Flutter::init()
 {
-	initialized = network.init(BAND);
+	initialized = network.init(band);
 	return initialized;
 }
 

--- a/src/Flutter.h
+++ b/src/Flutter.h
@@ -79,7 +79,7 @@ public:
 	Flutter();
 	volatile boolean initialized;
 	boolean synchronized;
-
+	byte band;
 
 	boolean init();
 	void setLED(int red, int green, int blue);

--- a/src/Network.h
+++ b/src/Network.h
@@ -36,7 +36,7 @@
 //Falure to properly set this value can result in serious harmful operation.
 //If not properly configured, the device may cause harmful interference to critical emergency services.
 //Use one of the values
-#define BAND REPLACE_THIS_TEXT_WITH_YOUR_REGION_FROM_ABOVE
+//#define BAND REPLACE_THIS_TEXT_WITH_YOUR_REGION_FROM_ABOVE
 
 #define FREQ_BANDS {865000000,902000000,915000000,925000000} //hz
 #define NUM_CHANNELS {60,520,260,60} //hz


### PR DESCRIPTION
Moved BAND definition from Network.h into the Flutter.h as a new class property named band.  This allows for the band to be set without modifying the library source file, which is needed anytime a code refresh from GitHub is performed.  This also makes the code much more transportable.
This will generate compiler errors if band is left unset.
